### PR TITLE
attachInterrupt method

### DIFF
--- a/bbio/config.py
+++ b/bbio/config.py
@@ -86,6 +86,7 @@ HIGH     =  1
 LOW      =  0
 RISING   =  1
 FALLING  = -1
+BOTH     =  0
 MSBFIRST =  1
 LSBFIRST = -1
 


### PR DESCRIPTION
Ok, here's a first pass at adding this!

Some notes:

1) This doesn't have any kind of debounce logic, so it can fire multiple events per trigger. I think this is how the Arduino one operates, though, so I tried to mimic that and leave it up to the user to handle debounce. What are your thoughts?
2) This uses all core Python libraries.
3) I didn't add anything for the docs.
4) This was a quick stab at it, so I might end up rearranging a couple things later if they come to mind.
5) I only tested in one scenario, using the code below for 'falling' pins (this was how my hardware was set up). It might be good to check in a few other scenarios for reliability before adding officially to the docs.

Here was my test code:

``` python
import time
from bbio import *

TEST_PIN1 = GPIO1_6
TEST_PIN2 = GPIO1_2

def print_one():
    print "one"

def print_two():
    print "two"

def setup():
    pinMode(TEST_PIN1, INPUT, pull=1)
    pinMode(TEST_PIN2, INPUT, pull=1)
    attachInterrupt(TEST_PIN1, print_one, FALLING)
    attachInterrupt(TEST_PIN2, print_two, FALLING)

def loop():
    time.sleep(1.0)

run(setup, loop)
```

Let me know how this looks!
