### PR TITLE
Added range slider to BBIOServer!

### DIFF
--- a/libraries/BBIOServer/bbio_server.py
+++ b/libraries/BBIOServer/bbio_server.py
@@ -256,7 +256,33 @@ class Page(object):
       '<div class="button" onclick="call_function(%s, \'entry\')">%s\n' % \
       (function_id, submit_label) +\
      '</div>\n</div>\n'
+    
+  def add_range(self, function, submit_label,minvalue=0,maxvalue=100,defaultvalue=50,stepsize=1, newline=False):
+    """ Add a range slider box and a submit button with the given label to the 
+        current position in the page. When submitted, the given function will
+        be called, passing it the value (as a string) currently in the slider. The function 
+        must take take a value, e.g.: 'lambda s: print s'. If newline=True 
+        the text will be put on a new line, otherwise it will be stacked on
+        the current line. """
 
+    # Create the unique id and store the function:
+    function_id = str(int(time.time()*1e6) & 0xffff)
+    FUNCTIONS[function_id] = function
+
+    style = "clear: left;" if newline else ''
+
+    # Add the HTML. Pass the Javascript function the function id,
+    # as well as a string to indicate it's an entry. This way the
+    # Javascript function will know to extract the text from the 
+    # entry and pass it as part of its request. 
+    self.html +=\
+      '<div class="object-wrapper" style="%s">\n' % (style) +\
+      '<input class="entry" id="%s" type="range" min=%s max=%s step=%s value=%s name="entry" />\n' %\
+      (function_id,minvalue,maxvalue,stepsize,defaultvalue) +\
+      '<div class="button" onclick="call_function(%s, \'entry\')">%s\n' % \
+      (function_id, submit_label) +\
+     '</div>\n</div>\n'
+    
   def add_monitor(self, function, label, units='', newline=False):
     """ Add a monitor to the current position in the page. It will be
         displayed in the format: 'label' 'value' 'units', where value is 
@@ -281,6 +307,7 @@ class Page(object):
       '<div class="monitor-field" id="%s"></div>\n' % (function_id) +\
       '<div class="value-field">%s</div>\n' % (units) +\
       '</div>\n'
+
 
   def __str__(self):
     # Return the HTML with the content of the footer template


### PR DESCRIPTION
So I'm not an expert on Python, HTML or BBB but while using pyBBIO
library I thought that a slider might be neat, so I checked the
BBIO_server source and specially the add_entry function and thought it
could not be that hard. Thus, I add add_range. It works just like
add_entry, but it takes some extra optional values as well that are
pretty much self explanatory:

minvalue is the minimum value of the slider (all the way to the left)
maxvalue is the maximum value of the slider (all the way to the right)
defaultvalue is the default value where the slider starts when you load
the page
stepsize is the size of the steps in the slider, so the amount of steps
you have ends up being (maxvalue-minvalue)/stepsize

It works with integers as well as floats and returns, as add_entry a
string that can be easily manipulated. Tested and working properly on
Firefox, Chrome and Safari, all of those in Mac OS X 10.9.4.

Hope this is helpful for someone other than me :)

Resubmitting it as I probably submitted it wrong the last time.
