### PR TITLE
docs: Fix a few typos

### DIFF
--- a/bbio/libraries/BBIOServer/bbio_server.py
+++ b/bbio/libraries/BBIOServer/bbio_server.py
@@ -163,7 +163,7 @@ class BBIOServer():
       with open(path, 'w') as f:
         f.write(str(page) % links)
 
-    # Start srver in a daemon thread:
+    # Start server in a daemon thread:
     server_thread = threading.Thread(target=self._server.serve_forever)
     server_thread.daemon = True
     server_thread.start()

--- a/examples/BBIOServer_mobile_test.py
+++ b/examples/BBIOServer_mobile_test.py
@@ -39,7 +39,7 @@ def print_entry(text):
   print "Text entered: \n  '%s'" % text
 
 def setup():
-  # Set the LEDs we'll be ontrolling as outputs:
+  # Set the LEDs we'll be controlling as outputs:
   pinMode(USR2, OUTPUT)
   pinMode(USR3, OUTPUT)
 

--- a/examples/BBIOServer_test.py
+++ b/examples/BBIOServer_test.py
@@ -35,7 +35,7 @@ def print_entry(text):
   print "Text entered: \n  '%s'" % text
 
 def setup():
-  # Set the LEDs we'll be ontrolling as outputs:
+  # Set the LEDs we'll be controlling as outputs:
   pinMode(USR2, OUTPUT)
   pinMode(USR3, OUTPUT)
 

--- a/examples/EventIO_test.py
+++ b/examples/EventIO_test.py
@@ -80,4 +80,4 @@ def loop():
 
 run(setup, loop)
 # As soon as ctrl-c is pressed the event loop process will be 
-# automatically termintated and the program wil exit happily.
+# automatically terminated and the program wil exit happily.

--- a/examples/knock.py
+++ b/examples/knock.py
@@ -1,6 +1,6 @@
 """
  knock.py - Alexander Hiam - 3/21/2012
- Adapted from the Ardiuno knock.pde example skecth for use
+ Adapted from the Ardiuno knock.pde example sketch for use
  with PyBBIO - https://github.com/alexanderhiam/PyBBIO
 
  Uses a Piezo element to detect knocks. If a knock is detected


### PR DESCRIPTION
There are small typos in:
- bbio/libraries/BBIOServer/bbio_server.py
- examples/BBIOServer_mobile_test.py
- examples/BBIOServer_test.py
- examples/EventIO_test.py
- examples/knock.py

Fixes:
- Should read `controlling` rather than `ontrolling`.
- Should read `terminated` rather than `termintated`.
- Should read `sketch` rather than `skecth`.
- Should read `server` rather than `srver`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md